### PR TITLE
[WIP] Add dataClay package to the repository

### DIFF
--- a/packages/compss/package.py
+++ b/packages/compss/package.py
@@ -37,7 +37,7 @@ class Compss(Package):
     version('2.10',       sha256='0795ca7674f1bdd0faeac950fa329377596494f64223650fe65a096807d58a60', preferred=True)
 
     # dependencies. 
-    depends_on('python@3.6')
+    depends_on('python@3.6:')
     depends_on('openjdk')
     depends_on('boost')
     depends_on('libxml2')

--- a/packages/py-dataclay/package.py
+++ b/packages/py-dataclay/package.py
@@ -1,0 +1,26 @@
+from spack.package import *
+
+
+class PyDataclay(PythonPackage):
+    """dataClay active object store."""
+
+    homepage = "https://dataclay.bsc.es"
+    pypi = "dataclay/dataclay-3.0.1.tar.gz"
+
+    maintainers = ["alexbarcelo", "support-dataclay"]
+
+    version("3.0.1", sha256="0cb7fb53eb7196d8e18bf11fcb85c5a0f8f09643e739c1be6b2ecceb3f7303a4")
+
+    # Python 3.10 required
+    depends_on("python@3.10:", type=("build", "run"))
+
+    # This project uses setuptools
+    depends_on("py-setuptools", type="build")
+
+    # Other dataclay dependencies
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-grpcio", type=("build", "run"))
+    depends_on("py-psutil", type=("build", "run"))
+    depends_on("py-protobuf", type=("build", "run"))
+    depends_on("py-redis", type=("build", "run"))
+    depends_on("py-bcrypt", type=("build", "run"))

--- a/packages/py-dislib/package.py
+++ b/packages/py-dislib/package.py
@@ -42,7 +42,7 @@ class PyDislib(PythonPackage):
     # FIXME: Add dependencies if required. Only add the python dependency
     # if you need specific versions. A generic python dependency is
     # added implicity by the PythonPackage class.
-    depends_on('python@3.6', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'))
     #depends_on('py-setuptools', type='build')
     depends_on('py-scikit-learn@0.23.2^py-scipy@1.5.0^py-numpy@1.19.5', type=('run'))
     #depends_on('py-scikit-learn', type=('run'))


### PR DESCRIPTION
`py-dataclay` folder contains de Python dataClay package.

For compatibility reasons, I needed to relax COMPSs & dislib Python requirements; otherwise, the environment ended up in an inconsistent state (i.e. Python 3.6 and Python 3.10 ill-combined)